### PR TITLE
All spans of a trace share sampling state

### DIFF
--- a/src/_flow/legacy_sampler_v1.js
+++ b/src/_flow/legacy_sampler_v1.js
@@ -1,0 +1,41 @@
+// @flow
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+declare interface LegacySamplerV1 {
+  name(): string;
+
+  /**
+   * Decides if a new trace starting with given operation name
+   * should be sampled or not. If the method returns true, it
+   * must populate the tags dictionary with tags that identify
+   * the sampler, namely sampler.type and sampler.param.
+   *
+   * This API is different from Python and Go, because Javascript
+   * does not allow functions to return multiple values. We would
+   * have to return an object like {sampled: bool, tags: map},
+   * which would require heap allocation every time, and in most
+   * cases will have sampled=false where tags are irrelevant.
+   * By passing tags as an out parameter we can minimize the
+   * allocations.
+   *
+   * @param {string} operation - Operation name of the root span.
+   * @param {Object} tags - output dictionary to store sampler tags.
+   * @return {boolean} - returns whether the trace should be sampled.
+   *
+   */
+  isSampled(operation: string, tags: any): boolean;
+
+  equal(other: LegacySamplerV1): boolean;
+
+  close(callback: ?Function): void;
+}

--- a/src/_flow/sampler.js
+++ b/src/_flow/sampler.js
@@ -11,31 +11,17 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+import Span from '../span';
+import type { SamplerApiVersion } from '../samplers/constants';
+
 declare interface Sampler {
+  apiVersion: SamplerApiVersion;
+  extendedStateNamespace(): string;
   name(): string;
-
-  /**
-   * Decides if a new trace starting with given operation name
-   * should be sampled or not. If the method returns true, it
-   * must populate the tags dictionary with tags that identify
-   * the sampler, namely sampler.type and sampler.param.
-   *
-   * This API is different from Python and Go, because Javascript
-   * does not allow functions to return multiple values. We would
-   * have to return an object like {sampled: bool, tags: map},
-   * which would require heap allocation every time, and in most
-   * cases will have sampled=false where tags are irrelevant.
-   * By passing tags as an out parameter we can minimize the
-   * allocations.
-   *
-   * @param {string} operation - Operation name of the root span.
-   * @param {Object} tags - output dictionary to store sampler tags.
-   * @return {boolean} - returns whether the trace should be sampled.
-   *
-   */
-  isSampled(operation: string, tags: any): boolean;
-
-  equal(other: Sampler): boolean;
-
+  onCreateSpan(span: Span): void;
+  onSetOperationName(span: Span, operationName: string): void;
+  onSetTag(span: Span, key: string, value: string): void;
+  // TODO(joe): confirm equal() is not necessary
+  // equal(other: LegacySamplerV1): boolean;
   close(callback: ?Function): void;
 }

--- a/src/baggage/baggage_setter.js
+++ b/src/baggage/baggage_setter.js
@@ -11,9 +11,9 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import Span from '../span.js';
-import SpanContext from '../span_context.js';
-import Metrics from '../metrics/metrics.js';
+import Span from '../span';
+import SpanContext from '../span_context';
+import Metrics from '../metrics/metrics';
 
 /**
  * BaggageSetter is a class that sets a baggage key:value and the associated

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const SAMPLED_MASK = 0b1;
 export const DEBUG_MASK = 0b10;
 
 // FIREHOSE_MASK is the bit mask indicationg a span is a firehose span.
-export const FIREHOSE_MASK = 0b100;
+export const FIREHOSE_MASK = 0b1000;
 
 // JAEGER_CLIENT_VERSION_TAG_KEY is the name of the tag used to report client version.
 export const JAEGER_CLIENT_VERSION_TAG_KEY = 'jaeger.version';

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,10 +11,13 @@
 // the License.
 
 // SAMPLED_MASK is the bit mask indicating that a span has been sampled.
-export const SAMPLED_MASK = 0x1;
+export const SAMPLED_MASK = 0b1;
 
 // DEBUG_MASK is the bit mask indicationg that a span has been marked for debug.
-export const DEBUG_MASK = 0x2;
+export const DEBUG_MASK = 0b10;
+
+// FIREHOSE_MASK is the bit mask indicationg a span is a firehose span.
+export const FIREHOSE_MASK = 0b100;
 
 // JAEGER_CLIENT_VERSION_TAG_KEY is the name of the tag used to report client version.
 export const JAEGER_CLIENT_VERSION_TAG_KEY = 'jaeger.version';

--- a/src/propagators/text_map_codec.js
+++ b/src/propagators/text_map_codec.js
@@ -11,11 +11,11 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import * as constants from '../constants.js';
-import Metrics from '../metrics/metrics.js';
+import * as constants from '../constants';
+import Metrics from '../metrics/metrics';
 import NoopMetricFactory from '../metrics/noop/metric_factory';
-import SpanContext from '../span_context.js';
-import Utils from '../util.js';
+import SpanContext from '../span_context';
+import Utils from '../util';
 import { parseCommaSeparatedBaggage } from '../propagators/baggage';
 
 export default class TextMapCodec {

--- a/src/reporters/composite_reporter.js
+++ b/src/reporters/composite_reporter.js
@@ -13,7 +13,7 @@
 
 import Span from '../span.js';
 
-export default class CompositeReporter {
+export default class CompositeReporter implements Reporter {
   _reporters: Array<Reporter>;
 
   constructor(reporters: Array<Reporter>) {

--- a/src/reporters/in_memory_reporter.js
+++ b/src/reporters/in_memory_reporter.js
@@ -14,7 +14,7 @@
 import Span from '../span.js';
 import ThriftUtils from '../thrift.js';
 
-export default class InMemoryReporter {
+export default class InMemoryReporter implements Reporter {
   _spans: Array<Span>;
   _process: Process;
 

--- a/src/reporters/logging_reporter.js
+++ b/src/reporters/logging_reporter.js
@@ -11,10 +11,10 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import Span from '../span.js';
-import NullLogger from '../logger.js';
+import Span from '../span';
+import NullLogger from '../logger';
 
-export default class LoggingReporter {
+export default class LoggingReporter implements Reporter {
   _logger: Logger;
 
   constructor(logger: Logger) {

--- a/src/reporters/noop_reporter.js
+++ b/src/reporters/noop_reporter.js
@@ -11,12 +11,14 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
+import Span from '../span';
+
 export default class NoopReporter implements Reporter {
   name(): string {
     return 'NoopReporter';
   }
 
-  report(span: any): void {}
+  report(span: Span): void {}
 
   close(callback?: () => void): void {
     if (callback) {

--- a/src/reporters/remote_reporter.js
+++ b/src/reporters/remote_reporter.js
@@ -18,7 +18,7 @@ import NoopMetricFactory from '../metrics/noop/metric_factory';
 
 const DEFAULT_BUFFER_FLUSH_INTERVAL_MILLIS = 1000;
 
-export default class RemoteReporter {
+export default class RemoteReporter implements Reporter {
   _bufferFlushInterval: number;
   _logger: Logger;
   _sender: Sender;

--- a/src/samplers/adapt_sampler.js
+++ b/src/samplers/adapt_sampler.js
@@ -1,0 +1,116 @@
+// @flow
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import getInstanceId from './get_instance_id';
+import { SAMPLER_API_V2 } from './constants';
+import Span from '../span';
+import Utils from '../util';
+
+type AdaptSamplerFn = {
+  (sampler: any): ?Sampler,
+  orThrow: (sampler: any) => Sampler,
+};
+
+function adaptSamplerFn(sampler: any): ?Sampler {
+  if (!sampler) {
+    return null;
+  }
+  if (sampler.apiVersion === SAMPLER_API_V2) {
+    // already v2 API compatible
+    return sampler;
+  }
+  if (!sampler.apiVersion) {
+    // v1 legacy sampler
+    return new LegacySamplerV1Adapter(sampler);
+  }
+  return null;
+}
+
+function adaptSamplerOrThrow(sampler: any): Sampler {
+  const s = adaptSampler(sampler);
+  if (!s) {
+    throw new Error(`Unrecognized sampler: ${sampler}`);
+  }
+  return s;
+}
+
+adaptSamplerFn.orThrow = adaptSamplerOrThrow;
+const adaptSampler: AdaptSamplerFn = adaptSamplerFn;
+export default adaptSampler;
+
+class LegacySamplerV1Adapter implements Sampler {
+  apiVersion = SAMPLER_API_V2;
+
+  _adaptee: LegacySamplerV1;
+  _extendedStateNamespace: string;
+
+  constructor(instance: LegacySamplerV1) {
+    this._adaptee = instance;
+    this._extendedStateNamespace = getInstanceId(this.name());
+  }
+
+  extendedStateNamespace() {
+    return this._extendedStateNamespace;
+  }
+
+  name() {
+    return `SamplerV1Adapter(${this._adaptee.name()})`;
+  }
+
+  onCreateSpan(span: Span) {
+    const samplingState = span._spanContext._samplingState;
+    if (samplingState.isFinal()) {
+      return;
+    }
+    if (!samplingState.isLocalRootSpan(span._spanContext)) {
+      // this is not the local root span, therefore we should attempt to
+      // finalize the sample decision (finalizing will be ignored if something
+      // has indicated the sampler state cannot be finalized).
+      samplingState.setIsFinal(true);
+    } else if (!samplingState.isSampled()) {
+      const tags = {};
+      const isSampled = this._adaptee.isSampled(span.operationName, tags);
+      if (isSampled) {
+        samplingState.setIsSampled(true);
+        const tagsArr = Utils.convertObjectToTags(tags);
+        for (let i = 0; i < tagsArr.length; i++) {
+          span._setTag(tagsArr[i].key, tagsArr[i].value);
+        }
+      }
+    }
+  }
+
+  onSetOperationName(span: Span, operationName: string) {
+    const samplingState = span._spanContext._samplingState;
+    if (samplingState.isFinal() || !samplingState.isLocalRootSpan(span._spanContext)) {
+      return;
+    }
+    samplingState.reset();
+    const tags = {};
+    const isSampled = this._adaptee.isSampled(span.operationName, tags);
+    if (isSampled) {
+      samplingState.setIsSampled(true);
+      samplingState.setIsFinal(true);
+      const tagsArr = Utils.convertObjectToTags(tags);
+      for (let i = 0; i < tagsArr.length; i++) {
+        span._setTag(tagsArr[i].key, tagsArr[i].value);
+      }
+    }
+  }
+
+  onSetTag(span: Span, key: string, value: string) {}
+
+  close(callback: ?Function) {
+    this._adaptee.close(callback);
+  }
+}

--- a/src/samplers/const_sampler.js
+++ b/src/samplers/const_sampler.js
@@ -13,7 +13,7 @@
 
 import * as constants from '../constants.js';
 
-export default class ConstSampler {
+export default class ConstSampler implements LegacySamplerV1 {
   _decision: boolean;
 
   constructor(decision: boolean) {
@@ -40,7 +40,7 @@ export default class ConstSampler {
     return this._decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof ConstSampler)) {
       return false;
     }

--- a/src/samplers/constants.js
+++ b/src/samplers/constants.js
@@ -1,5 +1,5 @@
 // @flow
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -11,18 +11,6 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-export default class NoopReporter implements Reporter {
-  name(): string {
-    return 'NoopReporter';
-  }
+export const SAMPLER_API_V2 = 'SAMPLER_API_V2';
 
-  report(span: any): void {}
-
-  close(callback?: () => void): void {
-    if (callback) {
-      callback();
-    }
-  }
-
-  setProcess(serviceName: string, tags: Array<Tag>): void {}
-}
+export type SamplerApiVersion = typeof SAMPLER_API_V2;

--- a/src/samplers/get_instance_id.js
+++ b/src/samplers/get_instance_id.js
@@ -1,5 +1,5 @@
 // @flow
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License. You may obtain a copy of the License at
@@ -11,18 +11,8 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-export default class NoopReporter implements Reporter {
-  name(): string {
-    return 'NoopReporter';
-  }
+let id = 0;
 
-  report(span: any): void {}
-
-  close(callback?: () => void): void {
-    if (callback) {
-      callback();
-    }
-  }
-
-  setProcess(serviceName: string, tags: Array<Tag>): void {}
+export default function getInstanceId(name: string) {
+  return `${id++}/${name}`;
 }

--- a/src/samplers/guaranteed_throughput_sampler.js
+++ b/src/samplers/guaranteed_throughput_sampler.js
@@ -22,7 +22,7 @@ import RateLimitingSampler from './ratelimiting_sampler.js';
 //
 // The probabilisticSampler is given higher priority when tags are emitted, ie. if IsSampled() for both
 // samplers return true, the tags for probabilisticSampler will be used.
-export default class GuaranteedThroughputSampler {
+export default class GuaranteedThroughputSampler implements LegacySamplerV1 {
   _probabilisticSampler: ProbabilisticSampler;
   _lowerBoundSampler: RateLimitingSampler;
   _tagsPlaceholder: any;
@@ -59,7 +59,7 @@ export default class GuaranteedThroughputSampler {
     return decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof GuaranteedThroughputSampler)) {
       return false;
     }

--- a/src/samplers/per_operation_sampler.js
+++ b/src/samplers/per_operation_sampler.js
@@ -23,7 +23,7 @@ type SamplersByOperation = { [key: string]: GuaranteedThroughputSampler, __proto
 // that all endpoints are represented in the sampled traces. If the number
 // of distinct operation names exceeds maxOperations, all other names are
 // sampled with a default probabilistic sampler.
-export default class PerOperationSampler {
+export default class PerOperationSampler implements LegacySamplerV1 {
   _maxOperations: number;
   _samplersByOperation: SamplersByOperation;
   _defaultSampler: ProbabilisticSampler;
@@ -78,7 +78,7 @@ export default class PerOperationSampler {
   }
 
   isSampled(operation: string, tags: any): boolean {
-    let sampler: Sampler = this._samplersByOperation[operation];
+    let sampler: LegacySamplerV1 = this._samplersByOperation[operation];
     if (!sampler) {
       if (Object.keys(this._samplersByOperation).length >= this._maxOperations) {
         return this._defaultSampler.isSampled(operation, tags);
@@ -89,7 +89,7 @@ export default class PerOperationSampler {
     return sampler.isSampled(operation, tags);
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     return false; // TODO equal should be removed
   }
 

--- a/src/samplers/probabilistic_sampler.js
+++ b/src/samplers/probabilistic_sampler.js
@@ -13,7 +13,7 @@
 
 import * as constants from '../constants.js';
 
-export default class ProbabilisticSampler {
+export default class ProbabilisticSampler implements LegacySamplerV1 {
   _samplingRate: number;
 
   constructor(samplingRate: number) {
@@ -51,7 +51,7 @@ export default class ProbabilisticSampler {
     return Math.random();
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof ProbabilisticSampler)) {
       return false;
     }

--- a/src/samplers/ratelimiting_sampler.js
+++ b/src/samplers/ratelimiting_sampler.js
@@ -14,7 +14,7 @@
 import * as constants from '../constants.js';
 import RateLimiter from '../rate_limiter.js';
 
-export default class RateLimitingSampler {
+export default class RateLimitingSampler implements LegacySamplerV1 {
   _rateLimiter: RateLimiter;
   _maxTracesPerSecond: number;
 
@@ -63,7 +63,7 @@ export default class RateLimitingSampler {
     return decision;
   }
 
-  equal(other: Sampler): boolean {
+  equal(other: LegacySamplerV1): boolean {
     if (!(other instanceof RateLimitingSampler)) {
       return false;
     }

--- a/src/samplers/remote_sampler.js
+++ b/src/samplers/remote_sampler.js
@@ -28,9 +28,9 @@ const DEFAULT_SAMPLING_PORT = 5778;
 const PROBABILISTIC_STRATEGY_TYPE = 'PROBABILISTIC';
 const RATELIMITING_STRATEGY_TYPE = 'RATE_LIMITING';
 
-export default class RemoteControlledSampler {
+export default class RemoteControlledSampler implements LegacySamplerV1 {
   _serviceName: string;
-  _sampler: Sampler;
+  _sampler: LegacySamplerV1;
   _logger: Logger;
   _metrics: Metrics;
 
@@ -152,7 +152,7 @@ export default class RemoteControlledSampler {
       this._sampler = new PerOperationSampler(response.operationSampling, this._maxOperations);
       return true;
     }
-    let newSampler: Sampler;
+    let newSampler: LegacySamplerV1;
     if (response.strategyType === PROBABILISTIC_STRATEGY_TYPE && response.probabilisticSampling) {
       let samplingRate = response.probabilisticSampling.samplingRate;
       newSampler = new ProbabilisticSampler(samplingRate);
@@ -177,6 +177,10 @@ export default class RemoteControlledSampler {
 
   isSampled(operation: string, tags: any): boolean {
     return this._sampler.isSampled(operation, tags);
+  }
+
+  equal(other: LegacySamplerV1): boolean {
+    return false;
   }
 
   close(callback: ?Function): void {

--- a/src/samplers/v2/const_sampler.js
+++ b/src/samplers/v2/const_sampler.js
@@ -17,7 +17,7 @@ import * as constants from '../../constants.js';
 import Span from '../../span';
 
 export default class ConstSamplerV2 implements Sampler {
-  apiVersion: ?string = SAMPLER_API_V2;
+  apiVersion = SAMPLER_API_V2;
   _decision: boolean;
   _extendedStateNamespace: string;
 
@@ -44,34 +44,18 @@ export default class ConstSamplerV2 implements Sampler {
 
   onCreateSpan(span: Span) {
     const ctx = span._spanContext;
-    if (this._decision && !ctx.samplingFinalized && !ctx.isSampled() && span.isLocalRootSpan()) {
-      ctx.setIsSampled(true);
-      // TODO(joe): Determine if any existing tags with same keys should be removed
+    if (this._decision && !ctx.samplingFinalized && !ctx.isSampled() && span._isLocalRootSpan()) {
+      ctx._setIsSampled(true);
       span._setTag(constants.SAMPLER_TYPE_TAG_KEY, constants.SAMPLER_TYPE_CONST);
       span._setTag(constants.SAMPLER_PARAM_TAG_KEY, this._decision);
     }
   }
 
   onSetOperationName(span: Span, operationName: string) {
-    const ctx = span.context();
-    if (!ctx.samplingFinalized && span.isLocalRootSpan()) {
-      // TODO(joe): Determine if any existing sampling related tags should be removed
-      // treat it like a new span, i.e. resample
-      ctx._samplingState.reset();
-      this.onCreateSpan(span);
-      ctx.finalizeSampling();
-    }
+    span._spanContext.finalizeSampling();
   }
 
   onSetTag(span: Span) {}
-
-  // TODO(joe): confirm remvoing equal is fine
-  // equal(other: LegacySamplerV1): boolean {
-  //   if (!(other instanceof ConstSamplerV2)) {
-  //     return false;
-  //   }
-  //   return this.decision === other.decision;
-  // }
 
   close(callback: ?Function): void {
     if (callback) {

--- a/src/samplers/v2/const_sampler.js
+++ b/src/samplers/v2/const_sampler.js
@@ -1,0 +1,81 @@
+// @flow
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import getInstanceId from '../get_instance_id';
+import { SAMPLER_API_V2 } from '../constants.js';
+import * as constants from '../../constants.js';
+import Span from '../../span';
+
+export default class ConstSamplerV2 implements Sampler {
+  apiVersion: ?string = SAMPLER_API_V2;
+  _decision: boolean;
+  _extendedStateNamespace: string;
+
+  constructor(decision: boolean) {
+    this._decision = Boolean(decision);
+    this._extendedStateNamespace = getInstanceId(this.name());
+  }
+
+  name() {
+    return 'ConstSampler';
+  }
+
+  extendedStateNamespace() {
+    return this._extendedStateNamespace;
+  }
+
+  toString() {
+    return `${this.name()}(version=2, ${this._decision ? 'always' : 'never'})`;
+  }
+
+  get decision() {
+    return this._decision;
+  }
+
+  onCreateSpan(span: Span) {
+    const ctx = span._spanContext;
+    if (this._decision && !ctx.samplingFinalized && !ctx.isSampled() && span.isLocalRootSpan()) {
+      ctx.setIsSampled(true);
+      // TODO(joe): Determine if any existing tags with same keys should be removed
+      span._setTag(constants.SAMPLER_TYPE_TAG_KEY, constants.SAMPLER_TYPE_CONST);
+      span._setTag(constants.SAMPLER_PARAM_TAG_KEY, this._decision);
+    }
+  }
+
+  onSetOperationName(span: Span, operationName: string) {
+    const ctx = span.context();
+    if (!ctx.samplingFinalized && span.isLocalRootSpan()) {
+      // TODO(joe): Determine if any existing sampling related tags should be removed
+      // treat it like a new span, i.e. resample
+      ctx._samplingState.reset();
+      this.onCreateSpan(span);
+      ctx.finalizeSampling();
+    }
+  }
+
+  onSetTag(span: Span) {}
+
+  // TODO(joe): confirm remvoing equal is fine
+  // equal(other: LegacySamplerV1): boolean {
+  //   if (!(other instanceof ConstSamplerV2)) {
+  //     return false;
+  //   }
+  //   return this.decision === other.decision;
+  // }
+
+  close(callback: ?Function): void {
+    if (callback) {
+      callback();
+    }
+  }
+}

--- a/src/samplers/v2/sampling_state.js
+++ b/src/samplers/v2/sampling_state.js
@@ -12,22 +12,18 @@
 // the License.
 
 import { DEBUG_MASK, FIREHOSE_MASK, SAMPLED_MASK } from '../../constants';
-import Span from '../../span';
 import SpanContext from '../../span_context';
 
 export const WARN_NOT_FINALIZABLE = 'This sampling state is not finalizable.';
 export const WARN_SHOULD_NOT_ENABLE_FINALIZABLE = 'Finalizable can only be changed to false';
 export const WARN_CANNOT_REVERT_FINALIZABLE = 'Setting finalizable to false cannot be reverted';
 export const WARN_CANNOT_REVERT_FINAL = 'The final state cannot be reverted.';
-// export const WARN_CANNOT_UNSAMPLE = 'The final state cannot be reverted.';
-// export const WARN_CANNOT_REMOVE_DEBUG = 'The debug flag cannot be reverted.';
-// export const WARN_CANNOT_REMOVE_FIREHOSE = 'The firehose flag cannot be reverted.';
 
 export default class SamplingState {
   _extendedState: { [string]: any } = {};
   _flags: number = 0;
-  _isFinal: boolean = false;
-  _isFinalizable: boolean = true;
+  _final: boolean = false;
+  _finalizable: boolean = true;
   _localRootSpanIdStr: ?string;
 
   constructor(localRootSpanIdStr: ?string) {
@@ -47,45 +43,38 @@ export default class SamplingState {
   }
 
   isFinalizable() {
-    return this._isFinalizable;
+    return this._finalizable;
   }
 
   setIsFinalizable(value: false): ?string {
     if (value) {
-      if (!this._isFinalizable) {
+      if (!this._finalizable) {
         return WARN_CANNOT_REVERT_FINALIZABLE;
       }
       return WARN_SHOULD_NOT_ENABLE_FINALIZABLE;
     }
-    this._isFinalizable = false;
-    this._isFinal = false;
+    this._finalizable = false;
+    this._final = false;
   }
 
   isFinal() {
-    return this._isFinal;
+    return this._final;
   }
 
   setIsFinal(value: boolean): ?string {
-    if (!this._isFinalizable) {
+    if (!this._finalizable) {
       return WARN_NOT_FINALIZABLE;
     }
-    // TODO(joe): verify this is the behavior we want
-    if (!value && this._isFinal) {
+    if (!value && this._final) {
       return WARN_CANNOT_REVERT_FINAL;
     }
-    this._isFinal = value;
+    this._final = value;
   }
 
   isSampled() {
     return Boolean(this._flags & SAMPLED_MASK);
   }
 
-  // setIsSampled(value: true) {
-  //   if (!value && this._isSampled) {
-  //     return WARN_CANNOT_UNSAMPLE;
-  //   }
-  //   this._toggleFlag(SAMPLED_MASK, enable);
-  // }
   setIsSampled(enable: boolean) {
     this._toggleFlag(SAMPLED_MASK, enable);
   }
@@ -94,12 +83,6 @@ export default class SamplingState {
     return Boolean(this._flags & DEBUG_MASK);
   }
 
-  // setIsDebug(value: true) {
-  //   if (!value && this.isDebug()) {
-  //     return WARN_CANNOT_REMOVE_DEBUG;
-  //   }
-  //   this._toggleFlag(DEBUG_MASK, value);
-  // }
   setIsDebug(enable: boolean) {
     this._toggleFlag(DEBUG_MASK, enable);
   }
@@ -108,12 +91,6 @@ export default class SamplingState {
     return Boolean(this._flags & FIREHOSE_MASK);
   }
 
-  // setIsFirehose(value: true) {
-  //   if (!value && this._isFirehose) {
-  //     return WARN_CANNOT_REMOVE_FIREHOSE;
-  //   }
-  //   this._toggleFlag(FIREHOSE_MASK, enable);
-  // }
   setIsFirehose(enable: boolean) {
     this._toggleFlag(FIREHOSE_MASK, enable);
   }
@@ -132,12 +109,5 @@ export default class SamplingState {
     } else {
       this._flags &= ~mask;
     }
-  }
-
-  reset() {
-    this._extendedState = {};
-    this._flags = 0;
-    this._isFinal = false;
-    this._isFinalizable = true;
   }
 }

--- a/src/samplers/v2/sampling_state.js
+++ b/src/samplers/v2/sampling_state.js
@@ -1,0 +1,143 @@
+// @flow
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+
+import { DEBUG_MASK, FIREHOSE_MASK, SAMPLED_MASK } from '../../constants';
+import Span from '../../span';
+import SpanContext from '../../span_context';
+
+export const WARN_NOT_FINALIZABLE = 'This sampling state is not finalizable.';
+export const WARN_SHOULD_NOT_ENABLE_FINALIZABLE = 'Finalizable can only be changed to false';
+export const WARN_CANNOT_REVERT_FINALIZABLE = 'Setting finalizable to false cannot be reverted';
+export const WARN_CANNOT_REVERT_FINAL = 'The final state cannot be reverted.';
+// export const WARN_CANNOT_UNSAMPLE = 'The final state cannot be reverted.';
+// export const WARN_CANNOT_REMOVE_DEBUG = 'The debug flag cannot be reverted.';
+// export const WARN_CANNOT_REMOVE_FIREHOSE = 'The firehose flag cannot be reverted.';
+
+export default class SamplingState {
+  _extendedState: { [string]: any } = {};
+  _flags: number = 0;
+  _isFinal: boolean = false;
+  _isFinalizable: boolean = true;
+  _localRootSpanIdStr: ?string;
+
+  constructor(localRootSpanIdStr: ?string) {
+    this._localRootSpanIdStr = localRootSpanIdStr;
+  }
+
+  isLocalRootSpan(context: SpanContext) {
+    return this._localRootSpanIdStr === context.spanIdStr;
+  }
+
+  extendedState() {
+    return this._extendedState;
+  }
+
+  localRootSpanId() {
+    return this._localRootSpanIdStr;
+  }
+
+  isFinalizable() {
+    return this._isFinalizable;
+  }
+
+  setIsFinalizable(value: false): ?string {
+    if (value) {
+      if (!this._isFinalizable) {
+        return WARN_CANNOT_REVERT_FINALIZABLE;
+      }
+      return WARN_SHOULD_NOT_ENABLE_FINALIZABLE;
+    }
+    this._isFinalizable = false;
+    this._isFinal = false;
+  }
+
+  isFinal() {
+    return this._isFinal;
+  }
+
+  setIsFinal(value: boolean): ?string {
+    if (!this._isFinalizable) {
+      return WARN_NOT_FINALIZABLE;
+    }
+    // TODO(joe): verify this is the behavior we want
+    if (!value && this._isFinal) {
+      return WARN_CANNOT_REVERT_FINAL;
+    }
+    this._isFinal = value;
+  }
+
+  isSampled() {
+    return Boolean(this._flags & SAMPLED_MASK);
+  }
+
+  // setIsSampled(value: true) {
+  //   if (!value && this._isSampled) {
+  //     return WARN_CANNOT_UNSAMPLE;
+  //   }
+  //   this._toggleFlag(SAMPLED_MASK, enable);
+  // }
+  setIsSampled(enable: boolean) {
+    this._toggleFlag(SAMPLED_MASK, enable);
+  }
+
+  isDebug() {
+    return Boolean(this._flags & DEBUG_MASK);
+  }
+
+  // setIsDebug(value: true) {
+  //   if (!value && this.isDebug()) {
+  //     return WARN_CANNOT_REMOVE_DEBUG;
+  //   }
+  //   this._toggleFlag(DEBUG_MASK, value);
+  // }
+  setIsDebug(enable: boolean) {
+    this._toggleFlag(DEBUG_MASK, enable);
+  }
+
+  isFirehose() {
+    return Boolean(this._flags & FIREHOSE_MASK);
+  }
+
+  // setIsFirehose(value: true) {
+  //   if (!value && this._isFirehose) {
+  //     return WARN_CANNOT_REMOVE_FIREHOSE;
+  //   }
+  //   this._toggleFlag(FIREHOSE_MASK, enable);
+  // }
+  setIsFirehose(enable: boolean) {
+    this._toggleFlag(FIREHOSE_MASK, enable);
+  }
+
+  flags() {
+    return this._flags;
+  }
+
+  setFlags(flags: number) {
+    this._flags = flags;
+  }
+
+  _toggleFlag(mask: number, enable: boolean) {
+    if (enable) {
+      this._flags |= mask;
+    } else {
+      this._flags &= ~mask;
+    }
+  }
+
+  reset() {
+    this._extendedState = {};
+    this._flags = 0;
+    this._isFinal = false;
+    this._isFinalizable = true;
+  }
+}

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -126,15 +126,15 @@ export default class SpanContext {
     this._samplingState.setFlags(flags);
   }
 
-  setIsSampled(value: boolean) {
+  _setIsSampled(value: boolean) {
     this._samplingState.setIsSampled(value);
   }
 
-  setIsDebug(value: boolean) {
+  _setIsDebug(value: boolean) {
     this._samplingState.setIsDebug(value);
   }
 
-  setIsFirehose(value: boolean) {
+  _setIsFirehose(value: boolean) {
     this._samplingState.setIsFirehose(value);
   }
 
@@ -154,7 +154,7 @@ export default class SpanContext {
     return this._samplingState.setIsFinal(true);
   }
 
-  isLocalRootSpan() {
+  _isLocalRootSpan() {
     return this._samplingState.isLocalRootSpan(this);
   }
 
@@ -196,7 +196,7 @@ export default class SpanContext {
     );
   }
 
-  makeChildContext(childId: any) {
+  _makeChildContext(childId: any) {
     const idIsStr = typeof childId === 'string';
     const _childId = idIsStr ? null : childId;
     const _childIdStr = idIsStr ? childId : null;

--- a/src/span_context.js
+++ b/src/span_context.js
@@ -11,8 +11,10 @@
 // or implied. See the License for the specific language governing permissions and limitations under
 // the License.
 
-import * as constants from './constants.js';
+import * as constants from './constants';
+import SamplingState from './samplers/v2/sampling_state';
 import Utils from './util.js';
+import Span from './span';
 
 export default class SpanContext {
   _traceId: any;
@@ -21,26 +23,9 @@ export default class SpanContext {
   _traceIdStr: ?string;
   _spanIdStr: ?string;
   _parentIdStr: ?string;
-  _flags: number;
   _baggage: any;
   _debugId: ?string;
-  /**
-   * This field exists to help distinguish between when a span can have a properly
-   * correlated operation name -> sampling rate mapping, and when it cannot.
-   * Adaptive sampling uses the operation name of a span to correlate it with
-   * a sampling rate.  If an operation name is set on a span after the span's creation
-   * then adaptive sampling cannot associate the operation name with the proper sampling rate.
-   * In order to correct this we allow a span to be written to, so that we can re-sample
-   * it in the case that an operation name is set after span creation. Situations
-   * where a span context's sampling decision is finalized include:
-   * - it has inherited the sampling decision from its parent
-   * - its debug flag is set via the sampling.priority tag
-   * - it is finish()-ed
-   * - setOperationName is called
-   * - it is used as a parent for another span
-   * - its context is serialized using injectors
-   * */
-  _samplingFinalized: boolean;
+  _samplingState: SamplingState;
 
   constructor(
     traceId: any,
@@ -49,10 +34,9 @@ export default class SpanContext {
     traceIdStr: ?string,
     spanIdStr: ?string,
     parentIdStr: ?string,
-    flags: number = 0,
     baggage: any = {},
     debugId: ?string = '',
-    samplingFinalized: boolean = false
+    samplingState: ?SamplingState
   ) {
     this._traceId = traceId;
     this._spanId = spanId;
@@ -60,10 +44,9 @@ export default class SpanContext {
     this._traceIdStr = traceIdStr;
     this._spanIdStr = spanIdStr;
     this._parentIdStr = parentIdStr;
-    this._flags = flags;
     this._baggage = baggage;
     this._debugId = debugId;
-    this._samplingFinalized = samplingFinalized;
+    this._samplingState = samplingState || new SamplingState(this.spanIdStr);
   }
 
   get traceId(): any {
@@ -109,7 +92,7 @@ export default class SpanContext {
   }
 
   get flags(): number {
-    return this._flags;
+    return this._samplingState.flags();
   }
 
   get baggage(): any {
@@ -121,7 +104,7 @@ export default class SpanContext {
   }
 
   get samplingFinalized(): boolean {
-    return this._samplingFinalized;
+    return this._samplingState.isFinal();
   }
 
   set traceId(traceId: Buffer): void {
@@ -140,7 +123,19 @@ export default class SpanContext {
   }
 
   set flags(flags: number): void {
-    this._flags = flags;
+    this._samplingState.setFlags(flags);
+  }
+
+  setIsSampled(value: boolean) {
+    this._samplingState.setIsSampled(value);
+  }
+
+  setIsDebug(value: boolean) {
+    this._samplingState.setIsDebug(value);
+  }
+
+  setIsFirehose(value: boolean) {
+    this._samplingState.setIsFirehose(value);
   }
 
   set baggage(baggage: any): void {
@@ -152,29 +147,37 @@ export default class SpanContext {
   }
 
   get isValid(): boolean {
-    return !!((this._traceId || this._traceIdStr) && (this._spanId || this._spanIdStr));
+    return Boolean((this._traceId || this._traceIdStr) && (this._spanId || this._spanIdStr));
   }
 
-  finalizeSampling(): void {
-    this._samplingFinalized = true;
+  finalizeSampling() {
+    return this._samplingState.setIsFinal(true);
+  }
+
+  isLocalRootSpan() {
+    return this._samplingState.isLocalRootSpan(this);
   }
 
   isDebugIDContainerOnly(): boolean {
-    return !this.isValid && this._debugId !== '';
+    return !this.isValid && Boolean(this._debugId);
   }
 
   /**
    * @return {boolean} - returns whether or not this span context was sampled.
    **/
   isSampled(): boolean {
-    return (this.flags & constants.SAMPLED_MASK) === constants.SAMPLED_MASK;
+    return this._samplingState.isSampled();
   }
 
   /**
    * @return {boolean} - returns whether or not this span context has a debug flag set.
    **/
   isDebug(): boolean {
-    return (this.flags & constants.DEBUG_MASK) === constants.DEBUG_MASK;
+    return this._samplingState.isDebug();
+  }
+
+  isFirehose(): boolean {
+    return this._samplingState.isFirehose();
   }
 
   withBaggageItem(key: string, value: string): SpanContext {
@@ -187,10 +190,26 @@ export default class SpanContext {
       this._traceIdStr,
       this._spanIdStr,
       this._parentIdStr,
-      this._flags,
       newBaggage,
       this._debugId,
-      this._samplingFinalized
+      this._samplingState
+    );
+  }
+
+  makeChildContext(childId: any) {
+    const idIsStr = typeof childId === 'string';
+    const _childId = idIsStr ? null : childId;
+    const _childIdStr = idIsStr ? childId : null;
+    return new SpanContext(
+      this._traceId,
+      _childId,
+      this._spanId,
+      this._traceIdStr,
+      _childIdStr,
+      this._spanIdStr,
+      this._baggage,
+      this._debugId,
+      this._samplingState
     );
   }
 
@@ -198,7 +217,9 @@ export default class SpanContext {
    * @return {string} - returns a string version of this span context.
    **/
   toString(): string {
-    return [this.traceIdStr, this.spanIdStr, this.parentIdStr || '0', this._flags.toString(16)].join(':');
+    return `${String(this.traceIdStr)}:${String(this.spanIdStr)}:${String(
+      this.parentIdStr || 0
+    )}:${this._samplingState.flags().toString(16)}`;
   }
 
   /**
@@ -245,17 +266,18 @@ export default class SpanContext {
     baggage: any = {},
     debugId: ?string = ''
   ): SpanContext {
-    return new SpanContext(
+    const ctx = new SpanContext(
       traceId,
       spanId,
       parentId,
       null, // traceIdStr: string,
       null, // spanIdStr: string,
       null, // parentIdStr: string,
-      flags,
       baggage,
       debugId
     );
+    ctx.flags = flags;
+    return ctx;
   }
 
   static withStringIds(
@@ -266,16 +288,17 @@ export default class SpanContext {
     baggage: any = {},
     debugId: ?string = ''
   ): SpanContext {
-    return new SpanContext(
+    const ctx = new SpanContext(
       null, // traceId,
       null, // spanId,
       null, // parentId,
       traceIdStr,
       spanIdStr,
       parentIdStr,
-      flags,
       baggage,
       debugId
     );
+    ctx.flags = flags;
+    return ctx;
   }
 }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -13,7 +13,7 @@
 
 import BinaryCodec from './propagators/binary_codec';
 import ConstSampler from './samplers/v2/const_sampler';
-import adaptSampler from './samplers/adapt_sampler';
+import adaptSampler from './samplers/_adapt_sampler';
 import * as constants from './constants';
 import * as opentracing from 'opentracing';
 import { Tags as otTags } from 'opentracing';
@@ -235,15 +235,15 @@ export default class Tracer {
       // TODO(joe): verify `hasValidParent`
       // old code was: parentContext && !parentContext.isDebugIDContainerOnly();
       hasValidParent = true;
-      ctx = parent.makeChildContext(id);
+      ctx = parent._makeChildContext(id);
       // finalize sampling for all span contexts of the parent.traceId trace
       parent.finalizeSampling();
     } else {
       ctx = new SpanContext(id, id);
       if (parent) {
         if (parent.isDebugIDContainerOnly() && this._isDebugAllowed(operationName)) {
-          ctx.setIsSampled(true);
-          ctx.setIsDebug(true);
+          ctx._setIsSampled(true);
+          ctx._setIsDebug(true);
           internalTags = {
             [constants.JAEGER_DEBUG_HEADER]: parent.debugId,
           };

--- a/test/init_tracer.js
+++ b/test/init_tracer.js
@@ -71,7 +71,7 @@ describe('initTracer', () => {
     };
     let tracer = initTracer(config);
 
-    expect(tracer._sampler).to.be.an.instanceof(RemoteSampler);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(RemoteSampler);
     expect(tracer._reporter).to.be.an.instanceof(RemoteReporter);
     tracer.close(done);
   });
@@ -96,7 +96,7 @@ describe('initTracer', () => {
       config.sampler = samplerConfig;
       let tracer = initTracer(config);
 
-      expect(tracer._sampler).to.be.an.instanceof(expectedType);
+      expect(tracer._sampler._adaptee).to.be.an.instanceof(expectedType);
       tracer.close();
       // TODO(oibe:head) test utils for expectedParam here?
     });
@@ -255,8 +255,8 @@ describe('initTracer', () => {
     );
     assert.equal(tracer._reporter._metrics._factory, metrics);
     assert.equal(tracer._reporter._logger, logger);
-    assert.equal(tracer._sampler._metrics._factory, metrics);
-    assert.equal(tracer._sampler._logger, logger);
+    assert.equal(tracer._sampler._adaptee._metrics._factory, metrics);
+    assert.equal(tracer._sampler._adaptee._logger, logger);
     tracer.close(done);
   });
 
@@ -378,18 +378,18 @@ describe('initTracerFromENV', () => {
     process.env.JAEGER_SAMPLER_TYPE = 'probabilistic';
     process.env.JAEGER_SAMPLER_PARAM = 0.5;
     let tracer = initTracerFromEnv();
-    expect(tracer._sampler).to.be.an.instanceof(ProbabilisticSampler);
-    assert.equal(tracer._sampler._samplingRate, 0.5);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(ProbabilisticSampler);
+    assert.equal(tracer._sampler._adaptee._samplingRate, 0.5);
     tracer.close();
 
     process.env.JAEGER_SAMPLER_TYPE = 'remote';
     process.env.JAEGER_SAMPLER_MANAGER_HOST_PORT = 'localhost:8080';
     process.env.JAEGER_SAMPLER_REFRESH_INTERVAL = 100;
     tracer = initTracerFromEnv();
-    expect(tracer._sampler).to.be.an.instanceof(RemoteSampler);
-    assert.equal(tracer._sampler._host, 'localhost');
-    assert.equal(tracer._sampler._port, 8080);
-    assert.equal(tracer._sampler._refreshInterval, 100);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(RemoteSampler);
+    assert.equal(tracer._sampler._adaptee._host, 'localhost');
+    assert.equal(tracer._sampler._adaptee._port, 8080);
+    assert.equal(tracer._sampler._adaptee._refreshInterval, 100);
     tracer.close();
   });
 
@@ -399,8 +399,8 @@ describe('initTracerFromENV', () => {
     process.env.JAEGER_SAMPLER_TYPE = 'probabilistic';
     process.env.JAEGER_SAMPLER_PARAM = 0.5;
     let tracer = initTracerFromEnv();
-    expect(tracer._sampler).to.be.an.instanceof(ProbabilisticSampler);
-    assert.equal(tracer._sampler._samplingRate, 0.5);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(ProbabilisticSampler);
+    assert.equal(tracer._sampler._adaptee._samplingRate, 0.5);
     tracer.close();
 
     process.env.JAEGER_SAMPLER_TYPE = 'remote';
@@ -408,10 +408,10 @@ describe('initTracerFromENV', () => {
     process.env.JAEGER_SAMPLER_PORT = 8080;
     process.env.JAEGER_SAMPLER_REFRESH_INTERVAL = 100;
     tracer = initTracerFromEnv();
-    expect(tracer._sampler).to.be.an.instanceof(RemoteSampler);
-    assert.equal(tracer._sampler._host, 'localhost');
-    assert.equal(tracer._sampler._port, 8080);
-    assert.equal(tracer._sampler._refreshInterval, 100);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(RemoteSampler);
+    assert.equal(tracer._sampler._adaptee._host, 'localhost');
+    assert.equal(tracer._sampler._adaptee._port, 8080);
+    assert.equal(tracer._sampler._adaptee._refreshInterval, 100);
     tracer.close();
   });
 
@@ -526,10 +526,10 @@ describe('initTracerFromENV', () => {
     };
     let tracer = initTracerFromEnv(config, options);
     assert.equal(tracer._serviceName, 'test-service-arg');
-    expect(tracer._sampler).to.be.an.instanceof(RemoteSampler);
-    assert.equal(tracer._sampler._host, 'localhost');
-    assert.equal(tracer._sampler._port, 8080);
-    assert.equal(tracer._sampler._refreshInterval, 100);
+    expect(tracer._sampler._adaptee).to.be.an.instanceof(RemoteSampler);
+    assert.equal(tracer._sampler._adaptee._host, 'localhost');
+    assert.equal(tracer._sampler._adaptee._port, 8080);
+    assert.equal(tracer._sampler._adaptee._refreshInterval, 100);
     assert.equal(tracer._tags['KEY2'], 'VALUE2');
     tracer.close(done);
   });

--- a/test/span.js
+++ b/test/span.js
@@ -13,7 +13,8 @@
 import _ from 'lodash';
 import { assert, expect } from 'chai';
 import ConstSampler from '../src/samplers/v2/const_sampler';
-import adaptSampler from '../src/samplers/adapt_sampler';
+import LegacyConstSampler from '../src/samplers/const_sampler';
+import adaptSampler from '../src/samplers/_adapt_sampler';
 import ProbabilisticSampler from '../src/samplers/probabilistic_sampler';
 import * as constants from '../src/constants';
 import InMemoryReporter from '../src/reporters/in_memory_reporter';
@@ -243,7 +244,7 @@ describe('span should', () => {
         });
         span.log({ logkeyOne: 'logValueOne' });
 
-        tracer._sampler = new ConstSampler(o.sampling);
+        tracer._sampler = adaptSampler.orThrow(new LegacyConstSampler(o.sampling));
         span.setOperationName('sampled-span');
         span.finish();
 

--- a/test/span.js
+++ b/test/span.js
@@ -12,18 +12,19 @@
 
 import _ from 'lodash';
 import { assert, expect } from 'chai';
-import ConstSampler from '../src/samplers/const_sampler.js';
+import ConstSampler from '../src/samplers/v2/const_sampler';
+import adaptSampler from '../src/samplers/adapt_sampler';
 import ProbabilisticSampler from '../src/samplers/probabilistic_sampler';
-import * as constants from '../src/constants.js';
-import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
+import * as constants from '../src/constants';
+import InMemoryReporter from '../src/reporters/in_memory_reporter';
 import JaegerTestUtils from '../src/test_util';
 import MockLogger from './lib/mock_logger';
 import * as opentracing from 'opentracing';
-import Span from '../src/span.js';
-import SpanContext from '../src/span_context.js';
+import Span from '../src/span';
+import SpanContext from '../src/span_context';
 import sinon from 'sinon';
-import Tracer from '../src/tracer.js';
-import Utils from '../src/util.js';
+import Tracer from '../src/tracer';
+import Utils from '../src/util';
 import DefaultThrottler from '../src/throttler/default_throttler';
 
 describe('span should', () => {
@@ -335,7 +336,7 @@ describe('span should', () => {
           'sampler.param': true,
         })
       );
-      tracer._sampler = new ProbabilisticSampler(1.0);
+      tracer._sampler = adaptSampler.orThrow(new ProbabilisticSampler(1.0));
       span.setOperationName('re-sampled-span');
 
       assert.equal(span.operationName, 're-sampled-span');
@@ -354,7 +355,7 @@ describe('span should', () => {
       assert.equal(span.operationName, 'new-span-one');
 
       // update sampler to something will always sample
-      tracer._sampler = new ProbabilisticSampler(1.0);
+      tracer._sampler = adaptSampler.orThrow(new ProbabilisticSampler(1.0));
 
       // The second cal lshould rename the operation name, but
       // not re-sample the span.  This is because finalize was set

--- a/test/span_context.js
+++ b/test/span_context.js
@@ -12,7 +12,7 @@
 
 import { assert } from 'chai';
 import * as constants from '../src/constants.js';
-import SpanContext from '../src/span_context.js';
+import SpanContext from '../src/span_context';
 import Utils from '../src/util.js';
 
 describe('SpanContext should', () => {
@@ -47,7 +47,7 @@ describe('SpanContext should', () => {
     assert.isOk(context.isSampled());
     assert.isOk(context.isDebug());
 
-    context._flags = 0;
+    context.flags = 0;
     assert.isNotOk(context.isSampled());
     assert.isNotOk(context.isDebug());
   });

--- a/test/tchannel_bridge.js
+++ b/test/tchannel_bridge.js
@@ -124,7 +124,6 @@ describe('test tchannel span bridge', () => {
 
           assert.isOk(TestUtils.hasTags(serverSpan, serverSpanTags));
           assert.isOk(TestUtils.hasTags(clientSpan, clientSpanTags));
-
           assert.equal(serverSpan.context().parentIdStr, clientSpan.context().spanIdStr);
           // If context exists then the following conditions are true
           // else the following conditons are false

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -127,7 +127,7 @@ describe('tracer should', () => {
     assert.deepEqual(span.context().parentId, parentId);
     assert.equal(span.context().flags, flags);
     assert.equal(span._startTime, start);
-    assert.equal(span._tags.length, 4);
+    assert.equal(span._tags.length, 2);
   });
 
   it('report a span with no tracer level tags', () => {

--- a/test/tracer.js
+++ b/test/tracer.js
@@ -12,16 +12,16 @@
 
 import _ from 'lodash';
 import { assert, expect } from 'chai';
-import ConstSampler from '../src/samplers/const_sampler.js';
-import * as constants from '../src/constants.js';
-import InMemoryReporter from '../src/reporters/in_memory_reporter.js';
+import ConstSampler from '../src/samplers/v2/const_sampler';
+import * as constants from '../src/constants';
+import InMemoryReporter from '../src/reporters/in_memory_reporter';
 import * as opentracing from 'opentracing';
-import SpanContext from '../src/span_context.js';
-import Tracer from '../src/tracer.js';
-import Utils from '../src/util.js';
-import Metrics from '../src/metrics/metrics.js';
-import LocalMetricFactory from './lib/metrics/local/metric_factory.js';
-import LocalBackend from './lib/metrics/local/backend.js';
+import SpanContext from '../src/span_context';
+import Tracer from '../src/tracer';
+import Utils from '../src/util';
+import Metrics from '../src/metrics/metrics';
+import LocalMetricFactory from './lib/metrics/local/metric_factory';
+import LocalBackend from './lib/metrics/local/backend';
 import sinon from 'sinon';
 import DefaultThrottler from '../src/throttler/default_throttler';
 import os from 'os';
@@ -127,7 +127,7 @@ describe('tracer should', () => {
     assert.deepEqual(span.context().parentId, parentId);
     assert.equal(span.context().flags, flags);
     assert.equal(span._startTime, start);
-    assert.equal(Object.keys(span._tags).length, 2);
+    assert.equal(span._tags.length, 4);
   });
 
   it('report a span with no tracer level tags', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

Lays the ground work for making sampling decisions based on span tags. These sampling decisions should affect all spans of a trace (within a given process) regardless of which span triggered the decision.

## Short description of the changes

### Sampler API

Enhance the sampler API to be able to make sampling decisions on:

- Span creation
- Setting the operation name (aside from the initial value)
- Setting tags

Add `src/_flow/legacy_sampler_v1.js` to capture the legacy sampler API.

Redefine `src/_flow/sampler.js` to match the new sampler API.

Implement `src/samplers/v2/const_sampler.js` with the new API.

Implement `src/samplers/adapt_sampler.js` to wrap legacy samplers with the new API.

### Share sampled state within a trace

Share sampling state across all span contexts of the same trace.

Add `src/samplers/v2/sampling_state.js` to share sampling state among spans of the same trace.

Revise `src/span_context.js` to use `SamplingState` instead of `_flags` and `_samplingFinalized`. Update various classes that referred to these fields.


